### PR TITLE
Always display colors in Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ FROM node:20.8.0-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV production
 ENV HOSTNAME 0.0.0.0
+ENV FORCE_COLOR 1
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs


### PR DESCRIPTION
The environment variable `FORCE_COLOR` is set to 0 by default, which causes both Next and ansis to not format colors. Since Docker almost always supports color (and colors are always added in pino-pretty anyway), I think that it's fair to make this change.