### PR TITLE
Use env variables for Gamma client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres?schema=public"
 GAMMA_API_KEY=key
+GAMMA_CLIENT_ID="id"
+GAMMA_CLIENT_SECRET="secret"
 GAMMA_ROOT_URL=http://localhost:8081
 NEXTAUTH_SECRET=secret
 NEXTAUTH_URL=http://localhost:3000/api/auth

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -7,8 +7,8 @@ export const authConfig: NextAuthOptions = {
   providers: [
     GammaProvider({
       authorizationURL: gammaUrl + '/api/oauth/authorize',
-      clientId: 'id',
-      clientSecret: 'secret',
+      clientId: process.env.GAMMA_CLIENT_ID || 'id',
+      clientSecret: process.env.GAMMA_CLIENT_SECRET || 'secret',
       profileUrl: gammaUrl + '/api/users/me',
       tokenURL: gammaUrl + '/api/oauth/token'
     })


### PR DESCRIPTION
Previously, we used a hardcoded client with `id` and `secret` credentials. This PR *should* fix that.