### PR TITLE
Scheduled news posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next-auth": "^4.24.5",
     "next-logger": "^3.0.2",
     "next-themes": "^0.2.1",
+    "node-schedule": "^2.1.1",
     "pino": "^8.18.0",
     "pino-pretty": "^10.3.1",
     "react": "^18.2.0",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.16",
+    "@types/node-schedule": "^2.1.6",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.18",
     "eslint": "^8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@prisma/client':
     specifier: ^5.9.1
@@ -25,6 +29,9 @@ dependencies:
   next-themes:
     specifier: ^0.2.1
     version: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
+  node-schedule:
+    specifier: ^2.1.1
+    version: 2.1.1
   pino:
     specifier: ^8.18.0
     version: 8.18.0
@@ -48,6 +55,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.11.16
     version: 20.11.16
+  '@types/node-schedule':
+    specifier: ^2.1.6
+    version: 2.1.6
   '@types/react':
     specifier: ^18.2.55
     version: 18.2.55
@@ -977,6 +987,12 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/node-schedule@2.1.6:
+    resolution: {integrity: sha512-6AlZSUiNTdaVmH5jXYxX9YgmF1zfOlbjUqw0EllTBmZCnN1R5RR/m/u3No1OiWR05bnQ4jM4/+w4FcGvkAtnKQ==}
+    dependencies:
+      '@types/node': 20.11.16
+    dev: true
+
   /@types/node@20.11.16:
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
     dependencies:
@@ -1591,6 +1607,13 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    dev: false
+
+  /cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.4.4
     dev: false
 
   /cross-spawn@7.0.3:
@@ -3342,6 +3365,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /long-timeout@0.1.1:
+    resolution: {integrity: sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==}
+    dev: false
+
   /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -3359,6 +3386,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /luxon@3.4.4:
+    resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
+    engines: {node: '>=12'}
+    dev: false
 
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3526,6 +3558,15 @@ packages:
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: false
+
+  /node-schedule@2.1.1:
+    resolution: {integrity: sha512-OXdegQq03OmXEjt2hZP33W2YPs/E5BcFQks46+G2gAxs4gHOIVD1u7EqlYLYSKsaIpyKCK9Gbk0ta1/gjRSMRQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      cron-parser: 4.9.0
+      long-timeout: 0.1.1
+      sorted-array-functions: 1.3.0
     dev: false
 
   /normalize-path@3.0.0:
@@ -4164,6 +4205,10 @@ packages:
       atomic-sleep: 1.0.0
     dev: false
 
+  /sorted-array-functions@1.3.0:
+    resolution: {integrity: sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==}
+    dev: false
+
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -4613,7 +4658,3 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model NewsPost {
   writtenFor           DivisionGroup? @relation(fields: [divisionGroupId], references: [id])
   mainImage            Media?         @relation(fields: [mediaSha256], references: [sha256])
   connectedEvents      Event[]
+  scheduledPublish     DateTime?
+  status               PostStatus     @default(DRAFT)
   createdAt            DateTime       @default(now())
   updatedAt            DateTime       @updatedAt
   divisionGroupId      Int?
@@ -101,4 +103,11 @@ enum NotifierType {
 enum Language {
   SV
   EN
+}
+
+enum PostStatus {
+  DRAFT
+  SCHEDULED
+  PUBLISHED
+  DELETED
 }

--- a/src/components/DatePicker/DatePicker.module.scss
+++ b/src/components/DatePicker/DatePicker.module.scss
@@ -1,0 +1,18 @@
+.picker {
+  border: none;
+  border-radius: 4px;
+  padding: 5px;
+  height: 2rem;
+  resize: none;
+  font-size: var(--text-normal);
+  color: var(--text-color);
+  background-color: var(--header-color);
+  &:focus {
+    outline: none;
+    border-color: #4d90fe;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+  }
+}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,0 +1,33 @@
+import styles from './DatePicker.module.scss';
+
+const convertToDateTimeLocalString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};
+
+const DatePicker = ({
+  value,
+  onChange,
+  disabled
+}: {
+  value: Date;
+  onChange: (_date: Date) => void;
+  disabled?: boolean;
+}) => {
+  return (
+    <input
+      className={styles.picker}
+      disabled={disabled}
+      type="datetime-local"
+      value={convertToDateTimeLocalString(value)}
+      onChange={(e) => onChange(new Date(e.target.value))}
+    />
+  );
+};
+
+export default DatePicker;

--- a/src/components/NewsList/NewsList.tsx
+++ b/src/components/NewsList/NewsList.tsx
@@ -5,6 +5,7 @@ import ActionButton from '../ActionButton/ActionButton';
 import SessionService from '@/services/sessionService';
 import ContentPane from '../ContentPane/ContentPane';
 import Divider from '../Divider/Divider';
+import { PostStatus } from '@prisma/client';
 
 interface NewsPostInterface {
   id: number;
@@ -15,6 +16,7 @@ interface NewsPostInterface {
   writtenByGammaUserId: string;
   createdAt: Date;
   updatedAt: Date;
+  status: PostStatus;
   writtenFor: {
     gammaSuperGroupId: string;
     prettyName: string;

--- a/src/components/NewsList/NewsPost/NewsPost.tsx
+++ b/src/components/NewsList/NewsPost/NewsPost.tsx
@@ -8,6 +8,7 @@ import ActionButton from '@/components/ActionButton/ActionButton';
 import DeletePostButton from './DeletePostButton';
 import MarkdownView from '@/components/MarkdownView/MarkdownView';
 import SessionService from '@/services/sessionService';
+import { PostStatus } from '@prisma/client';
 
 interface NewsPostProps {
   post: {
@@ -19,6 +20,7 @@ interface NewsPostProps {
     writtenByGammaUserId: string;
     createdAt: Date;
     updatedAt: Date;
+    status: PostStatus;
     writtenFor: {
       gammaSuperGroupId: string;
       prettyName: string;
@@ -26,39 +28,37 @@ interface NewsPostProps {
   };
 }
 
-type PropsThing = {
-  day: 'numeric';
-  month: 'numeric';
-  year: 'numeric';
-  hour: '2-digit';
-  minute: '2-digit';
+const formatDate = (date: Date) => {
+  return date
+    .toLocaleDateString(['sv-SE'], {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+    .replace(',', '');
 };
 
 const NewsPost = async ({ post }: NewsPostProps) => {
   const group = post.writtenFor?.prettyName;
 
   const nick =
-    (
-      await GammaService.getUser(post.writtenByGammaUserId).catch(
-        () => undefined
-      )
-    )?.user.nick || 'Unknown user';
+    (await GammaService.getNick(post.writtenByGammaUserId)) ||
+    'Okänd användare';
 
   const ownsPost =
     (await getServerSession(authConfig))?.user?.id ===
-      post.writtenByGammaUserId || post.writtenFor?.gammaSuperGroupId
+      post.writtenByGammaUserId ||
+    (post.writtenFor?.gammaSuperGroupId
       ? await SessionService.canEditGroup(post.writtenFor!.gammaSuperGroupId)
-      : false;
+      : false);
+
+  if (!ownsPost && post.status !== PostStatus.PUBLISHED) {
+    return null;
+  }
 
   const canDeletePost = ownsPost || (await SessionService.isAdmin());
-
-  const propsThing: PropsThing = {
-    day: 'numeric',
-    month: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit'
-  };
 
   return (
     <>
@@ -73,12 +73,11 @@ const NewsPost = async ({ post }: NewsPostProps) => {
         {canDeletePost && <DeletePostButton id={post.id} />}
       </div>
       <p className={style.subtitle}>
-        {post.createdAt.toLocaleString([], propsThing).replace(',', '')} |
-        Skriven {group && `för ${group}`} av {nick}{' '}
+        {post.status === PostStatus.SCHEDULED ? 'Schemalagd ' : null}
+        {formatDate(post.createdAt)} | Skriven {group && `för ${group}`} av{' '}
+        {nick}{' '}
         {post.updatedAt.getTime() - post.createdAt.getTime() > 5000 &&
-          ` | Redigerad ${post.updatedAt
-            .toLocaleString([], propsThing)
-            .replace(',', '')}`}
+          ` | Redigerad ${formatDate(post.updatedAt)}`}
       </p>
       <MarkdownView content={post.contentSv} />
     </>

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -11,6 +11,7 @@ import DropdownList from '../DropdownList/DropdownList';
 import { marked } from 'marked';
 import style from './NewsPostForm.module.scss';
 import Popup from 'reactjs-popup';
+import DatePicker from '../DatePicker/DatePicker';
 
 const PreviewContentStyle = {
   backgroundColor: '#000000AA'
@@ -40,7 +41,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const [contentEn, setContentEn] = useState(newsPost.contentEn ?? '');
   const [contentSv, setContentSv] = useState(newsPost.contentSv ?? '');
   const [publish, setPublish] = useState('now');
-  const [scheduledFor, setScheduledFor] = useState(Date.now().toString());
+  const [scheduledFor, setScheduledFor] = useState(new Date());
   const [showPreview, setShowPreview] = useState(false);
   const [previewContentSv, setPreviewContentSv] = useState({
     __html: marked.parse('')
@@ -53,6 +54,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
     try {
       const publishDate =
         publish === 'now' ? undefined : new Date(scheduledFor);
+
       if (newsPost.id !== undefined) {
         await edit(
           newsPost.id!,
@@ -128,13 +130,12 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
       <div className={style.actions}>
         <DropdownList onChange={(e) => setPublish(e.target.value)}>
           <option value="now">Nu</option>
-          <option value="schedule">Schemalägg</option>
+          <option value="schedule">Schemalagd</option>
         </DropdownList>
-        <input
+        <DatePicker
           disabled={publish === 'now'}
-          type="datetime-local"
           value={scheduledFor}
-          onChange={(e) => setScheduledFor(e.target.value)}
+          onChange={(e) => setScheduledFor(e)}
         />
       </div>
 

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -39,6 +39,8 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const [titleSv, setTitleSv] = useState(newsPost.titleSv ?? '');
   const [contentEn, setContentEn] = useState(newsPost.contentEn ?? '');
   const [contentSv, setContentSv] = useState(newsPost.contentSv ?? '');
+  const [publish, setPublish] = useState('now');
+  const [scheduledFor, setScheduledFor] = useState(Date.now().toString());
   const [showPreview, setShowPreview] = useState(false);
   const [previewContentSv, setPreviewContentSv] = useState({
     __html: marked.parse('')
@@ -49,6 +51,8 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
 
   async function send() {
     try {
+      const publishDate =
+        publish === 'now' ? undefined : new Date(scheduledFor);
       if (newsPost.id !== undefined) {
         await edit(
           newsPost.id!,
@@ -56,16 +60,24 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
           titleEn,
           titleSv,
           contentEn,
-          contentSv
+          contentSv,
+          publishDate
         );
         return;
       }
 
       if (group !== 'self') {
-        await postForGroup(titleEn, titleSv, contentEn, contentSv, group);
+        await postForGroup(
+          titleEn,
+          titleSv,
+          contentEn,
+          contentSv,
+          group,
+          publishDate
+        );
         return;
       } else {
-        await post(titleEn, titleSv, contentEn, contentSv);
+        await post(titleEn, titleSv, contentEn, contentSv, publishDate);
       }
     } catch {
       console.log('Failed to post news article');
@@ -83,7 +95,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
 
   return (
     <>
-      <h1>Skapa nyhet</h1>
+      <h1>{newsPost.id ? 'Redigera nyhet' : 'Skapa nyhet'}</h1>
       <Divider />
       <h2>Posta som</h2>
       <DropdownList onChange={(e) => setGroup(e.target.value)}>
@@ -110,6 +122,21 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         value={contentSv}
         onChange={(e) => setContentSv(e.target.value)}
       />
+
+      <br />
+      <h2>Publiceringstid</h2>
+      <div className={style.actions}>
+        <DropdownList onChange={(e) => setPublish(e.target.value)}>
+          <option value="now">Nu</option>
+          <option value="schedule">Schemalägg</option>
+        </DropdownList>
+        <input
+          disabled={publish === 'now'}
+          type="datetime-local"
+          value={scheduledFor}
+          onChange={(e) => setScheduledFor(e.target.value)}
+        />
+      </div>
 
       <br />
       <div className={style.actions}>

--- a/src/components/NewsPostForm/actions.ts
+++ b/src/components/NewsPostForm/actions.ts
@@ -4,20 +4,24 @@ import NewsService from '@/services/newsService';
 import { getServerSession } from 'next-auth/next';
 import { authConfig } from '@/auth/auth';
 import { redirect } from 'next/navigation';
+import { PostStatus } from '@prisma/client';
 
 export async function post(
   titleEn: string,
   titleSv: string,
   contentEn: string,
-  contentSv: string
+  contentSv: string,
+  scheduledPublish?: Date
 ) {
   const session = await getServerSession(authConfig);
   await NewsService.post({
-    titleEn: titleEn,
-    titleSv: titleSv,
-    contentEn: contentEn,
-    contentSv: contentSv,
-    writtenByGammaUserId: session?.user?.id!
+    titleEn,
+    titleSv,
+    contentEn,
+    contentSv,
+    scheduledPublish,
+    writtenByGammaUserId: session?.user?.id!,
+    status: scheduledPublish ? PostStatus.SCHEDULED : PostStatus.PUBLISHED
   });
   redirect('/');
 }
@@ -28,17 +32,19 @@ export async function edit(
   titleEn: string,
   titleSv: string,
   contentEn: string,
-  contentSv: string
+  contentSv: string,
+  scheduledPublish?: Date
 ) {
   if ((await getServerSession(authConfig))?.user?.id !== writtenByGammaUserId) {
     redirect('/');
   }
 
   await NewsService.edit({
-    titleEn: titleEn,
-    titleSv: titleSv,
-    contentEn: contentEn,
-    contentSv: contentSv,
+    titleEn,
+    titleSv,
+    contentEn,
+    contentSv,
+    scheduledPublish,
     id: id
   });
   redirect('/');
@@ -49,16 +55,19 @@ export async function postForGroup(
   titleSv: string,
   contentEn: string,
   contentSv: string,
-  divisionSuperGroupId: string
+  divisionSuperGroupId: string,
+  scheduledPublish?: Date
 ) {
   const session = await getServerSession(authConfig);
   await NewsService.post({
-    titleEn: titleEn,
-    titleSv: titleSv,
-    contentEn: contentEn,
-    contentSv: contentSv,
+    titleEn,
+    titleSv,
+    contentEn,
+    contentSv,
+    divisionSuperGroupId,
+    scheduledPublish,
     writtenByGammaUserId: session?.user?.id!,
-    divisionSuperGroupId: divisionSuperGroupId
+    status: scheduledPublish ? PostStatus.SCHEDULED : PostStatus.PUBLISHED
   });
   redirect('/');
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,3 +1,6 @@
+import schedule from 'node-schedule';
+import NewsService from './services/newsService';
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     console.log('Patching logger');
@@ -6,5 +9,11 @@ export async function register() {
     await require('colorette');
     await require('ansis/colors');
     await require('next-logger');
+
+    console.log('Scheduling tasks');
+    const rule = new schedule.RecurrenceRule();
+    rule.second = 0;
+
+    schedule.scheduleJob(rule, NewsService.publishScheduled);
   }
 }

--- a/src/services/gammaService.ts
+++ b/src/services/gammaService.ts
@@ -12,6 +12,10 @@ export default class GammaService {
     return await gammaGetRequest<GammaUserInfo>(`/info/v1/users/${uuid}`);
   }
 
+  static async getNick(uuid: string) {
+    return (await this.getUser(uuid).catch(() => undefined))?.user.nick;
+  }
+
   static getUserAvatarURL(uuid: string) {
     return `${gammaUrl}/images/user/avatar/${uuid}`;
   }


### PR DESCRIPTION
# Key features:
- Track states for draft, scheduled, published, and soft-deleted posts using an enum in the database (although published and scheduled states is only used for now)
- Only show scheduled posts for editing to the authoring user or group
- Use a scheduler to publish posts when needed
- Closes #7
- Closes #23
- Closes #55

# Known issues:
- ~~The date picker is initialized as an empty value~~ *Fixed!*