### PR TITLE
Make GammaProvider more generic

### DIFF
--- a/src/auth/GammaProvider.ts
+++ b/src/auth/GammaProvider.ts
@@ -1,48 +1,21 @@
 import { OAuthConfig, OAuthUserConfig } from 'next-auth/providers/oauth';
 import { GammaProfile } from '@/types/gamma';
 
-export interface GammaProviderConfig extends OAuthUserConfig<GammaProfile> {
-  url: string;
-  profileEndpoint: string;
-  clientId: string;
-  clientSecret: string;
-}
-
 export default function GammaProvider(
-  gammaConfig: GammaProviderConfig
+  config: OAuthUserConfig<GammaProfile>
 ): OAuthConfig<GammaProfile> {
   return {
     id: 'gamma',
     name: 'Gamma',
     type: 'oauth',
-    wellKnown: gammaConfig.url + '/.well-known/openid-configuration',
+    idToken: true,
     authorization: { params: { scope: 'openid profile' } },
-    userinfo: {
-      async request(context) {
-        const response = await fetch(
-          gammaConfig.url + gammaConfig.profileEndpoint,
-          {
-            headers: {
-              Authorization: `Bearer ${context.tokens.access_token}`
-            }
-          }
-        );
-
-        if (!response.ok) {
-          throw new Error('Failed to fetch user data!');
-        }
-
-        return (await response.json()) as GammaProfile;
-      }
-    },
-    profile(profile: GammaProfile) {
-      return {
-        id: profile.sub,
-        name: profile.nickname,
-        email: profile.email,
-        image: profile.picture
-      };
-    },
-    options: gammaConfig
+    profile: (p: GammaProfile) => ({
+      id: p.sub,
+      name: p.nickname,
+      email: p.email,
+      image: p.picture
+    }),
+    options: config
   };
 }

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -6,10 +6,9 @@ const gammaUrl = process.env.GAMMA_ROOT_URL?.replace(/\/$/, '');
 export const authConfig: NextAuthOptions = {
   providers: [
     GammaProvider({
-      url: gammaUrl!,
-      profileEndpoint: '/userinfo',
-      clientId: process.env.GAMMA_CLIENT_ID || 'id',
-      clientSecret: process.env.GAMMA_CLIENT_SECRET || 'secret'
+      wellKnown: gammaUrl,
+      clientId: process.env.GAMMA_CLIENT_ID ?? 'id',
+      clientSecret: process.env.GAMMA_CLIENT_SECRET ?? 'secret'
     })
   ],
   callbacks: {

--- a/src/types/gamma.ts
+++ b/src/types/gamma.ts
@@ -76,6 +76,8 @@ export interface GammaProfile {
   sub: string;
   picture: string;
   email?: string;
+  name: string;
+  cid: string;
   given_name: string;
   family_name: string;
   nickname: string;


### PR DESCRIPTION
- Pull `userinfo` from ID token automatically instead of /userinfo endpoint
- Add some missing fields
- Remove `GammaProviderConfig` interface entirely