### PR TITLE
Allow img tag for sanitized HTML

### DIFF
--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -11,7 +11,9 @@ const MarkdownView = ({ content }: { content: string }) => {
 
   const renderMarkdownText = () => {
     const rawMarkup = marked.parse(content) as string;
-    const sanitizedMarkup = sanitizeHtml(rawMarkup);
+    const sanitizedMarkup = sanitizeHtml(rawMarkup, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img'])
+    });
     return { __html: sanitizedMarkup };
   };
 


### PR DESCRIPTION
Allow images to be embedded from markdown as the default sanitization does not allow it.