### PR TITLE
Escape instead of discard sanitized HTML

### DIFF
--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -12,7 +12,8 @@ const MarkdownView = ({ content }: { content: string }) => {
   const renderMarkdownText = () => {
     const rawMarkup = marked.parse(content) as string;
     const sanitizedMarkup = sanitizeHtml(rawMarkup, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img'])
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+      disallowedTagsMode: 'escape'
     });
     return { __html: sanitizedMarkup };
   };


### PR DESCRIPTION
The default for the sanitization is to discard illegal tags, we want to just escape it instead so it is obvious that it is not allowed.