### PR TITLE
Show toast to give feedback when a media link is copied

### DIFF
--- a/src/components/DivisionPageForm/DivisionPageForm.tsx
+++ b/src/components/DivisionPageForm/DivisionPageForm.tsx
@@ -76,6 +76,7 @@ const DivisionPageForm = (divisionPost: DivisionPostFormProps) => {
 
   const copyFile = (sha256: string) => {
     navigator.clipboard.writeText('[Text](/api/media/' + sha256 + ')');
+    toast(l.editor.linkCopied, { type: 'success' });
   };
 
   function preview() {

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -107,6 +107,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
 
   const copyFile = (sha256: string) => {
     navigator.clipboard.writeText('[Text](/api/media/' + sha256 + ')');
+    toast(l.editor.linkCopied, { type: 'success' });
   };
 
   async function send() {

--- a/src/components/PageForm/PageForm.tsx
+++ b/src/components/PageForm/PageForm.tsx
@@ -62,6 +62,7 @@ const PageForm = (description: NewPostFormProps) => {
 
   const copyFile = (sha256: string) => {
     navigator.clipboard.writeText('[Text](/api/media/' + sha256 + ')');
+    toast(l.editor.linkCopied, { type: 'success' });
   };
 
   function preview() {

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -83,7 +83,8 @@
     "saveError": "Could not save news post!",
     "posting": "Creating...",
     "posted": "Created!",
-    "postError": "Could not create news post!"
+    "postError": "Could not create news post!",
+    "linkCopied": "Link copied!"
   },
   "pages": {
     "about": "About our division",

--- a/src/dictionaries/sv.json
+++ b/src/dictionaries/sv.json
@@ -82,7 +82,8 @@
     "saveError": "Kunde inte spara nyhet!",
     "posting": "Skapar...",
     "posted": "Skapad!",
-    "postError": "Kunde inte skapa nyhet!"
+    "postError": "Kunde inte skapa nyhet!",
+    "linkCopied": "Länk kopierad!"
   },
   "pages": {
     "about": "Om sektionen",


### PR DESCRIPTION
Shows a toast when a user copies a link.
Makes it more obvious that the button did something.