### PR TITLE
Return 404 if locale is invalid on root

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,7 +10,6 @@ import { ThemeProvider } from '@/components/ThemeProvider/ThemeProvider';
 import TopLoader from '@/components/TopLoader/TopLoader';
 import i18nService from '@/services/i18nService';
 import ToastContainerWrapper from '@/components/ToastContainerWrapper/ToastContainerWrapper';
-import NotFound from '@/components/ErrorPages/404/404';
 
 const poppins = Poppins({ weight: ['400'], subsets: ['latin'] });
 
@@ -30,6 +29,8 @@ export function generateStaticParams() {
   return i18nConfig.locales.map((locale) => ({ locale }));
 }
 
+export const dynamicParams = false;
+
 export default function RootLayout({
   children,
   params: { locale }
@@ -37,7 +38,6 @@ export default function RootLayout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
-  const invalidLocale = locale !== 'en' && locale !== 'sv';
   return (
     <html lang={locale}>
       <body style={{ display: 'unset' }} className={poppins.className}>
@@ -45,7 +45,7 @@ export default function RootLayout({
           <TopLoader />
           <Header locale={locale} />
           <Banner locale={locale} />
-          {invalidLocale ? <NotFound /> : children}
+          {children}
           <ToastContainerWrapper />
         </ThemeProvider>
       </body>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@/components/ThemeProvider/ThemeProvider';
 import TopLoader from '@/components/TopLoader/TopLoader';
 import i18nService from '@/services/i18nService';
 import ToastContainerWrapper from '@/components/ToastContainerWrapper/ToastContainerWrapper';
+import NotFound from '@/components/ErrorPages/404/404';
 
 const poppins = Poppins({ weight: ['400'], subsets: ['latin'] });
 
@@ -36,6 +37,7 @@ export default function RootLayout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
+  const invalidLocale = locale !== 'en' && locale !== 'sv';
   return (
     <html lang={locale}>
       <body style={{ display: 'unset' }} className={poppins.className}>
@@ -43,7 +45,7 @@ export default function RootLayout({
           <TopLoader />
           <Header locale={locale} />
           <Banner locale={locale} />
-          {children}
+          {invalidLocale ? <NotFound /> : children}
           <ToastContainerWrapper />
         </ThemeProvider>
       </body>


### PR DESCRIPTION
Solves an issue where you would end up at the landing page with the `sv` locale (due to `i18nService` defaulting to that) if you use a path that bypasses the middleware (e.g. by visiting `/this.does.not.exist`), but does not match a valid locale. See i18nexus/next-i18n-router#78 for more context.