### PR TITLE
Manually check if locale is valid

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from '@/components/ThemeProvider/ThemeProvider';
 import TopLoader from '@/components/TopLoader/TopLoader';
 import i18nService from '@/services/i18nService';
 import ToastContainerWrapper from '@/components/ToastContainerWrapper/ToastContainerWrapper';
+import NotFound from '@/components/ErrorPages/404/404';
 
 const poppins = Poppins({ weight: ['400'], subsets: ['latin'] });
 
@@ -38,6 +39,7 @@ export default function RootLayout({
   children: React.ReactNode;
   params: { locale: string };
 }) {
+  const invalidLocale = !i18nConfig.locales.includes(locale);
   return (
     <html lang={locale}>
       <body style={{ display: 'unset' }} className={poppins.className}>
@@ -45,7 +47,7 @@ export default function RootLayout({
           <TopLoader />
           <Header locale={locale} />
           <Banner locale={locale} />
-          {children}
+          {invalidLocale ? <NotFound /> : children}
           <ToastContainerWrapper />
         </ThemeProvider>
       </body>


### PR DESCRIPTION
This adds an additional check if the locale is valid.
Context: vercel/next.js#54270