### PR TITLE
Properly check group ID permission

### DIFF
--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -43,15 +43,10 @@ export default class SessionService {
   }
 
   static async canEditGroupByInternalId(id: number, s?: Session | null) {
-    const session = s ?? (await SessionService.getSession());
-
     const gammaSuperGroupId =
       await DivisionGroupService.getGammaSuperGroupIdFromInternalId(id);
 
-    const activeGroups = session?.user?.id
-      ? await DivisionGroupService.getUserActiveGroups(session?.user?.id!)
-      : [];
-    return activeGroups.some((g) => g?.id === gammaSuperGroupId);
+    return gammaSuperGroupId ? this.canEditGroup(gammaSuperGroupId, s) : [];
   }
 
   static async isActive(s?: Session | null) {


### PR DESCRIPTION
Fixes an issue where `canEditGroupByInternalId` checks matching groups by searching for matching group IDs and not their corresponding super group IDs.