### PR TITLE
Show and edit scheduled publish date better

### DIFF
--- a/src/actions/newsList.ts
+++ b/src/actions/newsList.ts
@@ -17,6 +17,7 @@ export const getData = async (
     writtenByGammaUserId: string;
     createdAt: Date;
     updatedAt: Date;
+    scheduledPublish: Date | null;
     status: PostStatus;
     writtenFor: {
       gammaSuperGroupId: string;
@@ -54,6 +55,7 @@ export const getData = async (
       post.updatedAt.getTime() - post.createdAt.getTime() > 5000
         ? post.updatedAt
         : undefined,
+    scheduledPublish: post.scheduledPublish ?? undefined,
     status: post.status,
     writtenFor: group,
     editable: ownsPost,

--- a/src/actions/newsPosts.ts
+++ b/src/actions/newsPosts.ts
@@ -45,7 +45,7 @@ export async function edit(
   contentEn: string,
   contentSv: string,
   files: FormData,
-  scheduledPublish?: Date
+  scheduledPublish?: Date | null
 ) {
   if (!(await SessionService.isNewsPostOwner(id))) {
     throw new Error('Unauthorized');

--- a/src/app/[locale]/post/[id]/edit/page.tsx
+++ b/src/app/[locale]/post/[id]/edit/page.tsx
@@ -41,6 +41,7 @@ export default async function Page({
               writtenByGammaUserId={newsPost!.writtenByGammaUserId}
               connectedEvents={newsPost!.connectedEvents}
               group={newsPost!.writtenFor?.gammaSuperGroupId}
+              scheduledPublish={newsPost!.scheduledPublish}
             />
           </ContentPane>
         }

--- a/src/components/NewsList/NewsList.tsx
+++ b/src/components/NewsList/NewsList.tsx
@@ -17,6 +17,7 @@ interface NewsPostInterface {
   author?: string;
   createdAt: Date;
   updatedAt?: Date;
+  scheduledPublish?: Date;
   status: PostStatus;
   writtenFor?: string;
   deletable: boolean;

--- a/src/components/NewsList/NewsPost/NewsPost.tsx
+++ b/src/components/NewsList/NewsPost/NewsPost.tsx
@@ -15,6 +15,7 @@ interface NewsPostProps {
     author?: string;
     createdAt: Date;
     updatedAt?: Date;
+    scheduledPublish?: Date;
     status: PostStatus;
     writtenFor?: string;
     deletable: boolean;

--- a/src/components/NewsList/NewsPost/NewsPostMeta/NewsPostMeta.tsx
+++ b/src/components/NewsList/NewsPost/NewsPostMeta/NewsPostMeta.tsx
@@ -10,16 +10,21 @@ const NewsPostMeta = ({
     author?: string;
     createdAt: Date;
     updatedAt?: Date;
+    scheduledPublish?: Date;
     status: PostStatus;
     writtenFor?: string;
   };
   locale: string;
 }) => {
   const l = i18nService.getLocale(locale);
+  const scheduled = post.status === PostStatus.SCHEDULED;
+  const date = scheduled
+    ? post.scheduledPublish ?? post.createdAt
+    : post.createdAt;
   return (
     <p className={styles.subtitle}>
-      {post.status === PostStatus.SCHEDULED ? `${l.news.scheduled} ` : null}
-      {`${i18nService.formatDate(post.createdAt)} | ${l.news.written} `}
+      {scheduled ? `${l.news.scheduled} ` : null}
+      {`${i18nService.formatDate(date)} | ${l.news.written} `}
       {post.writtenFor && `${l.news.for} ${post.writtenFor}`}{' '}
       {`${l.news.by} ${post.author ?? l.news.unknown} `}
       {post.updatedAt &&

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -35,6 +35,7 @@ interface NewPostFormProps {
   contentSv?: string;
   writtenByGammaUserId?: string;
   locale: string;
+  scheduledPublish?: Date | null;
   connectedEvents?: Event[];
 }
 
@@ -73,8 +74,12 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const [titleSv, setTitleSv] = useState(newsPost.titleSv ?? '');
   const [contentEn, setContentEn] = useState(newsPost.contentEn ?? '');
   const [contentSv, setContentSv] = useState(newsPost.contentSv ?? '');
-  const [publish, setPublish] = useState('now');
-  const [scheduledFor, setScheduledFor] = useState(new Date());
+  const [publish, setPublish] = useState(
+    newsPost.scheduledPublish ? 'schedule' : 'now'
+  );
+  const [scheduledFor, setScheduledFor] = useState(
+    newsPost.scheduledPublish ?? new Date()
+  );
   const [showPreview, setShowPreview] = useState(false);
   const [previewContentSv, setPreviewContentSv] = useState('');
   const [previewContentEn, setPreviewContentEn] = useState('');
@@ -294,7 +299,10 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
       <br />
       <h2>{l.editor.publish}</h2>
       <div className={style.actions}>
-        <DropdownList onChange={(e) => setPublish(e.target.value)}>
+        <DropdownList
+          value={publish}
+          onChange={(e) => setPublish(e.target.value)}
+        >
           <option value="now">{l.editor.now}</option>
           <option value="schedule">{l.editor.scheduled}</option>
         </DropdownList>

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -134,7 +134,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
             contentEn,
             contentSv,
             formData,
-            publishDate
+            publish === 'now' ? null : publishDate
           ),
           {
             pending: l.editor.saving,
@@ -304,7 +304,12 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
           onChange={(e) => setPublish(e.target.value)}
         >
           <option value="now">{l.editor.now}</option>
-          <option value="schedule">{l.editor.scheduled}</option>
+          <option
+            disabled={newsPost.scheduledPublish === null}
+            value="schedule"
+          >
+            {l.editor.scheduled}
+          </option>
         </DropdownList>
         <DatePicker
           hidden={publish === 'now'}

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -22,6 +22,7 @@ export default class NewsService {
         updatedAt: true,
         writtenByGammaUserId: true,
         status: true,
+        scheduledPublish: true,
         writtenFor: {
           select: {
             gammaSuperGroupId: true,
@@ -82,6 +83,7 @@ export default class NewsService {
         contentSv: true,
         createdAt: true,
         updatedAt: true,
+        scheduledPublish: true,
         writtenByGammaUserId: true,
         status: true,
         writtenFor: {
@@ -201,6 +203,7 @@ export default class NewsService {
         contentSv: true,
         createdAt: true,
         updatedAt: true,
+        scheduledPublish: true,
         writtenByGammaUserId: true,
         status: true,
         writtenFor: {

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -159,8 +159,18 @@ export default class NewsService {
     contentEn: string;
     contentSv: string;
     id: number;
-    scheduledPublish?: Date;
+    scheduledPublish?: Date | null;
   }) {
+    const post = await prisma.newsPost.findUnique({
+      where: {
+        id: edited.id
+      }
+    });
+
+    const updateScheduledPublish = post?.scheduledPublish !== null;
+    const publish =
+      edited.scheduledPublish === null && post?.status === PostStatus.SCHEDULED;
+
     return await prisma.newsPost.update({
       where: {
         id: edited.id
@@ -170,7 +180,10 @@ export default class NewsService {
         titleSv: edited.titleSv,
         contentEn: edited.contentEn,
         contentSv: edited.contentSv,
-        scheduledPublish: edited.scheduledPublish
+        status: publish ? PostStatus.PUBLISHED : undefined,
+        scheduledPublish: updateScheduledPublish
+          ? edited.scheduledPublish
+          : undefined
       }
     });
   }


### PR DESCRIPTION
# Key Features
- Fixes an issue where the creation date is displayed instead of the scheduled publish date
- Fixes an issue where a post's scheduled publish date cannot be edited
- Prevent "unpublishing" a post (making it scheduled again) due to potential strange behavior (e.g. multiple notifications for the same post)