### PR TITLE
Misc. page fixes

### DIFF
--- a/src/app/(groups)/[locale]/groups/[id]/layout.tsx
+++ b/src/app/(groups)/[locale]/groups/[id]/layout.tsx
@@ -9,8 +9,28 @@ import TopLoader from '@/components/TopLoader/TopLoader';
 import ToastContainerWrapper from '@/components/ToastContainerWrapper/ToastContainerWrapper';
 import DivisionGroupService from '@/services/divisionGroupService';
 import GammaService from '@/services/gammaService';
+import { Metadata } from 'next';
+import i18nService from '@/services/i18nService';
 
 const poppins = Poppins({ weight: ['400'], subsets: ['latin'] });
+
+export async function generateMetadata({
+  params: { locale, id }
+}: {
+  params: { locale: string; id: string };
+}) {
+  const group = await DivisionGroupService.getInfoBySlug(id).catch(() => {
+    return null;
+  });
+  const l = i18nService.getLocale(locale);
+  return {
+    title:
+      group !== null
+        ? group.prettyName + ' - ' + l.site.siteTitle
+        : l.site.siteTitle,
+    description: l.site.siteDescription
+  } as Metadata;
+}
 
 export const dynamicParams = false;
 

--- a/src/components/DivisionPageForm/DivisionPageForm.tsx
+++ b/src/components/DivisionPageForm/DivisionPageForm.tsx
@@ -247,7 +247,7 @@ const DivisionPageForm = (divisionPost: DivisionPostFormProps) => {
       <div className={styles.actions}>
         <ActionButton onClick={apply}>
           {divisionPost.editedId !== undefined
-            ? l.general.edit
+            ? l.general.save
             : l.general.create}
         </ActionButton>
         <ActionButton onClick={preview}>Förhandsgranska</ActionButton>

--- a/src/components/MarkdownView/MarkdownView.tsx
+++ b/src/components/MarkdownView/MarkdownView.tsx
@@ -2,6 +2,11 @@ import { marked } from 'marked';
 import style from './MarkdownView.module.scss';
 import sanitizeHtml from 'sanitize-html';
 
+const customAllowedTags = sanitizeHtml.defaults.allowedTags.concat(['img']);
+const customAllowedSchemes = sanitizeHtml.defaults.allowedSchemes.concat([
+  'blob'
+]);
+
 const MarkdownView = ({
   content,
   allowBlob = false
@@ -18,10 +23,11 @@ const MarkdownView = ({
   const renderMarkdownText = () => {
     const rawMarkup = marked.parse(content) as string;
     const sanitizedMarkup = sanitizeHtml(rawMarkup, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+      allowedTags: customAllowedTags,
       disallowedTagsMode: 'escape',
-      allowedSchemes:
-        allowBlob && sanitizeHtml.defaults.allowedSchemes.concat(['blob'])
+      allowedSchemes: allowBlob
+        ? customAllowedSchemes
+        : sanitizeHtml.defaults.allowedSchemes
     });
     return { __html: sanitizedMarkup };
   };

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -393,7 +393,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
       <br />
       <div className={style.actions}>
         <ActionButton onClick={send}>
-          {newsPost.id !== undefined ? l.general.edit : l.general.create}
+          {newsPost.id !== undefined ? l.general.save : l.general.create}
         </ActionButton>
         <ActionButton onClick={preview}>{l.editor.previewAction}</ActionButton>
       </div>

--- a/src/components/PageForm/PageForm.tsx
+++ b/src/components/PageForm/PageForm.tsx
@@ -159,7 +159,7 @@ const PageForm = (description: NewPostFormProps) => {
       <br />
       <div className={styles.actions}>
         <ActionButton onClick={send}>
-          {description.id !== undefined ? l.general.edit : l.general.create}
+          {description.id !== undefined ? l.general.save : l.general.create}
         </ActionButton>
         <ActionButton onClick={preview}>{l.editor.previewAction}</ActionButton>
       </div>

--- a/src/dictionaries/en.json
+++ b/src/dictionaries/en.json
@@ -7,7 +7,8 @@
     "download": "Download",
     "upload": "Upload",
     "uploaded": "Uploaded",
-    "close": "Close"
+    "close": "Close",
+    "save": "Save"
   },
   "site": {
     "siteTitle": "IT at Chalmers",

--- a/src/dictionaries/sv.json
+++ b/src/dictionaries/sv.json
@@ -7,7 +7,8 @@
     "download": "Ladda ner",
     "upload": "Ladda upp",
     "uploaded": "Uppladdad",
-    "close": "Stäng"
+    "close": "Stäng",
+    "save": "Spara"
   },
   "site": {
     "siteTitle": "IT på Chalmers",

--- a/src/services/notifyService.ts
+++ b/src/services/notifyService.ts
@@ -88,7 +88,7 @@ class DiscordWebhookNotifier implements Notifier {
         embeds: [
           {
             title: title,
-            url: `http://${process.env.BASE_URL || 'localhost:3000'}/post/${
+            url: `${process.env.BASE_URL ?? 'http://localhost:3000'}/post/${
               post.id
             }`,
             description: content,
@@ -145,8 +145,8 @@ class SlackWebhookNotifier implements Notifier {
                 type: 'section',
                 text: {
                   type: 'mrkdwn',
-                  text: `*<http://${
-                    process.env.BASE_URL || 'localhost:3000'
+                  text: `*<${
+                    process.env.BASE_URL ?? 'http://localhost:3000'
                   }/post/${post.id}|${title}>*`
                 }
               },


### PR DESCRIPTION
# Key features
- Edit forms: Display "Save" instead of "Edit" as a submit button
  - Partly resolves issue #108
- MarkdownView: Properly allow default schemes when `allowBlob` is false
  - Closes #111
- Main group pages: Add titles
- (Hijacking this PR) News notifiers: Remove hardcoded http scheme when sending notifiers

# Known issues
- Don't know any