### PR TITLE
Periodically update super group pretty-names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chalmers.it
 
-An ongoing rewrite of [chalmersit-rails](https://github.com/cthit/chalmersit-rails) in Next.js
+A rewrite and redesign of [chalmersit-rails](https://github.com/cthit/chalmersit-rails) in Next.js
 
 ## Suggestions and Contributions
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,6 @@
 import schedule from 'node-schedule';
 import NewsService from './services/newsService';
+import DivisionGroupService from './services/divisionGroupService';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
@@ -11,9 +12,13 @@ export async function register() {
     await require('next-logger');
 
     console.log('Scheduling tasks');
-    const rule = new schedule.RecurrenceRule();
-    rule.second = 0;
+    const newsPublishRule = new schedule.RecurrenceRule();
+    newsPublishRule.second = 0;
 
-    schedule.scheduleJob(rule, NewsService.publishScheduled);
+    schedule.scheduleJob(newsPublishRule, NewsService.publishScheduled);
+    schedule.scheduleJob(
+      '0 0 * * 1',
+      DivisionGroupService.updatePrettyNamesFromGamma
+    );
   }
 }

--- a/src/services/divisionGroupService.ts
+++ b/src/services/divisionGroupService.ts
@@ -135,4 +135,21 @@ export default class DivisionGroupService {
       })
     )?.gammaSuperGroupId;
   }
+
+  static async updatePrettyNamesFromGamma() {
+    const groups = await prisma.divisionGroup.findMany();
+    const gammaGroups = await GammaService.getAllSuperGroups();
+
+    for (const group of groups) {
+      const gammaGroup = gammaGroups.find(
+        (g) => g.superGroup.id === group.gammaSuperGroupId
+      );
+      if (gammaGroup === undefined) continue;
+
+      await prisma.divisionGroup.update({
+        where: { id: group.id },
+        data: { prettyName: gammaGroup.superGroup.prettyName }
+      });
+    }
+  }
 }


### PR DESCRIPTION
Fixes an issue where division group names cannot be changed in the system.
Currently set up to do a refresh every Monday at 00:00. There is no way to manually trigger this as of now.