### PR TITLE
Parse markdown to blocks in Slack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chalmers.it",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.9.1",
+    "@tryfabric/mack": "^1.2.1",
     "ansis": "^1.5.6",
     "jest": "^29.7.0",
     "marked": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sanitize-html": "^2.13.0"
   },
   "devDependencies": {
+    "@slack/types": "^2.13.0",
     "@types/node": "^20.11.16",
     "@types/node-schedule": "^2.1.6",
     "@types/react": "^18.2.55",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@prisma/client':
         specifier: ^5.9.1
         version: 5.9.1(prisma@5.9.1)
+      '@tryfabric/mack':
+        specifier: ^1.2.1
+        version: 1.2.1
       ansis:
         specifier: ^1.5.6
         version: 1.5.6
@@ -530,8 +533,15 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@slack/types@2.13.0':
+    resolution: {integrity: sha512-OAQVtKYIgBVNRmgIoiTjorGPTlgfcfstU3XYYCBA+czlB9aGcKb9MQc+6Jovi4gq3S98yP/GPBZsJSI/2mHKDQ==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
   '@swc/helpers@0.5.2':
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
+
+  '@tryfabric/mack@1.2.1':
+    resolution: {integrity: sha512-qQKj3l4x/7fWPHyk3zO3hPK2NUTH8AINJnVbdBYforWpm+6RDzp22gFIE66BJd2z7EFmt7F9aUOyZTKwmxiXrA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1302,6 +1312,10 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-xml-parser@4.5.0:
+    resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
+    hasBin: true
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -1913,6 +1927,11 @@ packages:
   marked@11.2.0:
     resolution: {integrity: sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==}
     engines: {node: '>= 18'}
+    hasBin: true
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
     hasBin: true
 
   mem@8.1.1:
@@ -2533,6 +2552,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -3278,9 +3300,17 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@slack/types@2.13.0': {}
+
   '@swc/helpers@0.5.2':
     dependencies:
       tslib: 2.6.2
+
+  '@tryfabric/mack@1.2.1':
+    dependencies:
+      '@slack/types': 2.13.0
+      fast-xml-parser: 4.5.0
+      marked: 4.3.0
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4282,6 +4312,10 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-xml-parser@4.5.0:
+    dependencies:
+      strnum: 1.0.5
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -5064,6 +5098,8 @@ snapshots:
 
   marked@11.2.0: {}
 
+  marked@4.3.0: {}
+
   mem@8.1.1:
     dependencies:
       map-age-cleaner: 0.1.3
@@ -5724,6 +5760,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@1.0.5: {}
 
   styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
         specifier: ^2.13.0
         version: 2.13.0
     devDependencies:
+      '@slack/types':
+        specifier: ^2.13.0
+        version: 2.13.0
       '@types/node':
         specifier: ^20.11.16
         version: 20.11.16

--- a/src/app/api/media/[...file]/route.ts
+++ b/src/app/api/media/[...file]/route.ts
@@ -6,6 +6,8 @@ export async function GET(
   ctx: { params: { file: string[] } }
 ) {
   const res = await MediaService.load(ctx.params.file.join('/'));
+  if (res === null)
+    return new NextResponse(null, { status: 404, statusText: 'Not Found' });
 
   const headers = new Headers();
   headers.set('Content-Type', res.extension);

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -1,6 +1,7 @@
 import prisma from '@/prisma';
 import { stat, readdir, readFile, writeFile } from 'fs/promises';
 import FileService, { MediaType } from './fileService';
+import { existsSync } from 'fs';
 
 const mediaPath = process.env.MEDIA_PATH || './media';
 
@@ -67,8 +68,12 @@ export default class MediaService {
       }
     });
 
+    if (extension === null) return null;
+
     const meta = FileService.convertMimeType(extension!.extension);
     const filename = sha256 + '.' + meta?.extension;
+
+    if (!existsSync(`${mediaPath}/${filename}`)) return null;
 
     return {
       data: await readFile(`${mediaPath}/${filename}`),

--- a/src/services/notifyService.ts
+++ b/src/services/notifyService.ts
@@ -175,7 +175,6 @@ class SlackWebhookNotifier implements Notifier {
         this.language === Language.EN ? post.contentEn : post.contentSv
       )
     );
-    console.log(JSON.stringify(content));
     const msg =
       this.language === Language.EN
         ? `News published${group ? ` for *${group.prettyName}*` : ''} by *${nick}*`
@@ -210,11 +209,16 @@ class SlackWebhookNotifier implements Notifier {
                   }>*`
                 }
               },
+              {
+                type: 'divider'
+              },
               ...content
             ]
           }
         ] as MessageAttachment[]
       })
+        .replaceAll('&#39;', "\\'")
+        .replaceAll('&quot;', '\\"')
     });
     if (!res.ok)
       console.trace(


### PR DESCRIPTION
# Key Features
- Display for which group a news post was posted for
- Closes #119 
- Parse markdown into Block Kit for news post notifiers (images, links, and formatting works again!)
- Merge consecutive `section` blocks (to prevent unnecessary "See more" links)
- Display large text for post title
- Show permalink underneath title
- Handle cases to prevent invalid attachments/request payloads

<details>
<summary>Screenshots</summary>

![image](https://github.com/user-attachments/assets/25913e4b-b03f-473f-b6cb-e5e5dbd83803)
![image](https://github.com/user-attachments/assets/8e79fba1-edb5-409a-abb0-c14854b32f6e)
</details>

# Known Issues
- There was barely any porting work done for Discord webhooks
  - Since we don't use it currently, I'm personally fine with this