### PR TITLE
Fix link to documents

### DIFF
--- a/src/components/Header/Navigation/Navigation.tsx
+++ b/src/components/Header/Navigation/Navigation.tsx
@@ -25,7 +25,7 @@ const Navigation = ({ locale, desktop }: Props) => {
       >
         <Link href="/pages">{l.pages.about}</Link>
         <Link href="/groups">{l.pages.groups}</Link>
-        <Link href="/documents">{l.docs.operational}</Link>
+        <Link href="/pages/documents">{l.docs.operational}</Link>
         <Link
           target="_blank"
           href="https://docs.chalmers.it/"


### PR DESCRIPTION
"Verksamhetsdokument" in the Navbar takes you to an empty page /documents, while a populated page /pages/documents exists.

