### PR TITLE
Fix manually published scheduled posts

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -181,6 +181,7 @@ export default class NewsService {
         contentEn: edited.contentEn,
         contentSv: edited.contentSv,
         status: publish ? PostStatus.PUBLISHED : undefined,
+        createdAt: publish ? new Date() : undefined,
         scheduledPublish: updateScheduledPublish
           ? edited.scheduledPublish
           : undefined

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -171,7 +171,7 @@ export default class NewsService {
     const publish =
       edited.scheduledPublish === null && post?.status === PostStatus.SCHEDULED;
 
-    return await prisma.newsPost.update({
+    const updatedPost = await prisma.newsPost.update({
       where: {
         id: edited.id
       },
@@ -187,6 +187,10 @@ export default class NewsService {
           : undefined
       }
     });
+
+    if (publish) NotifyService.notifyNewsPost(updatedPost);
+
+    return updatedPost;
   }
 
   static async remove(id: number) {


### PR DESCRIPTION
# Key features
- Correct publish date when changing from scheduled publish to published now
- Notifications sent when the above condition occurs

# Known issues
- None that I know of


# Description

Previously if a scheduled post was manually published ahead of the scheduled publish time the publish time would be used as the createdAt date. This caused posts to appear to be from the future (see example below) an therefor appear on top of any other published news item util that original scheduled publish date.

This pr fixes this as well as ensuring that a notification is sent out if a news post is manually published as before it would just be skipped forever.

This image was taken on 2024-12-08.
![image](https://github.com/user-attachments/assets/269e2712-c565-4c67-85a7-a70f2f88414e)


