### PR TITLE
Add isPageEditor permission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ README.md
 .git
 media
 .env*
+db

--- a/README.md
+++ b/README.md
@@ -50,18 +50,19 @@ This project uses environment variables to configure its behavior.
 
 The following environment variables are used:
 
-| Variable                  | Description                                                     | Example Value                                                          |
-| ------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| DATABASE_URL              | Database connection URL                                         | `postgresql://postgres:postgres@localhost:5432/postgres?schema=public` |
-| GAMMA_API_KEY_ID          | Gamma info API key ID                                           | `api-key-id-uuid-here`                                                 |
-| GAMMA_API_KEY_TOKEN       | Gamma info API token                                            | `token`                                                                |
-| GAMMA_CLIENT_ID           | Gamma OAuth client ID                                           | `id`                                                                   |
-| GAMMA_CLIENT_SECRET       | Gamma OAuth client secret                                       | `secret`                                                               |
-| GAMMA_ROOT_URL            | Gamma root URL                                                  | `https://auth.chalmers.it`                                             |
-| BASE_URL                  | URL that is used as a base for linking to news                  | `https://chalmers.it`                                                  |
-| NEXTAUTH_SECRET           | Secret used for signing cookies                                 | `secret`                                                               |
-| NEXTAUTH_URL              | URL to the NextAuth API                                         | `http://localhost:3000/api/auth`                                       |
-| MEDIA_PATH                | Path to store media                                             | `./media`                                                              |
-| ACTIVE_GROUP_TYPES        | Comma-separated list of group types that are considered active  | `committee,society`                                                    |
-| ADMIN_GROUPS              | Comma-separated list of groups that are considered admin groups | `styrit`                                                               |
-| CORPORATE_RELATIONS_GROUP | Group that is considered the corporate relations group          | `armit`                                                                |
+| Variable                  | Description                                                                                  | Example Value                                                          |
+|---------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| DATABASE_URL              | Database connection URL                                                                      | `postgresql://postgres:postgres@localhost:5432/postgres?schema=public` |
+| GAMMA_API_KEY_ID          | Gamma info API key ID                                                                        | `api-key-id-uuid-here`                                                 |
+| GAMMA_API_KEY_TOKEN       | Gamma info API token                                                                         | `token`                                                                |
+| GAMMA_CLIENT_ID           | Gamma OAuth client ID                                                                        | `id`                                                                   |
+| GAMMA_CLIENT_SECRET       | Gamma OAuth client secret                                                                    | `secret`                                                               |
+| GAMMA_ROOT_URL            | Gamma root URL                                                                               | `https://auth.chalmers.it`                                             |
+| BASE_URL                  | URL that is used as a base for linking to news                                               | `https://chalmers.it`                                                  |
+| NEXTAUTH_SECRET           | Secret used for signing cookies                                                              | `secret`                                                               |
+| NEXTAUTH_URL              | URL to the NextAuth API                                                                      | `http://localhost:3000/api/auth`                                       |
+| MEDIA_PATH                | Path to store media                                                                          | `./media`                                                              |
+| ACTIVE_GROUP_TYPES        | Comma-separated list of group types that are considered active                               | `committee,society`                                                    |
+| ADMIN_GROUPS              | Comma-separated list of groups that are considered admin groups                              | `styrit,digit`                                                               |
+| PAGE_EDITOR_GROUPS        | Comma-separated list of groups that are allowed to edit division pages in addition to admins | 'snit,motespresidit'                                                               |
+| CORPORATE_RELATIONS_GROUP | Group that is considered the corporate relations group                                       | `armit`                                                                |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project uses environment variables to configure its behavior.
 The following environment variables are used:
 
 | Variable                  | Description                                                                                  | Example Value                                                          |
-|---------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| ------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | DATABASE_URL              | Database connection URL                                                                      | `postgresql://postgres:postgres@localhost:5432/postgres?schema=public` |
 | GAMMA_API_KEY_ID          | Gamma info API key ID                                                                        | `api-key-id-uuid-here`                                                 |
 | GAMMA_API_KEY_TOKEN       | Gamma info API token                                                                         | `token`                                                                |
@@ -63,6 +63,6 @@ The following environment variables are used:
 | NEXTAUTH_URL              | URL to the NextAuth API                                                                      | `http://localhost:3000/api/auth`                                       |
 | MEDIA_PATH                | Path to store media                                                                          | `./media`                                                              |
 | ACTIVE_GROUP_TYPES        | Comma-separated list of group types that are considered active                               | `committee,society`                                                    |
-| ADMIN_GROUPS              | Comma-separated list of groups that are considered admin groups                              | `styrit,digit`                                                               |
-| PAGE_EDITOR_GROUPS        | Comma-separated list of groups that are allowed to edit division pages in addition to admins | 'snit,motespresidit'                                                               |
+| ADMIN_GROUPS              | Comma-separated list of groups that are considered admin groups                              | `styrit,digit`                                                         |
+| PAGE_EDITOR_GROUPS        | Comma-separated list of groups that are allowed to edit division pages in addition to admins | `snit,motespresidit`                                                   |
 | CORPORATE_RELATIONS_GROUP | Group that is considered the corporate relations group                                       | `armit`                                                                |

--- a/src/app/[locale]/pages/page.tsx
+++ b/src/app/[locale]/pages/page.tsx
@@ -24,14 +24,17 @@ export default async function Groups({
 }
 
 const Pages = async ({ locale }: { locale: string }) => {
-  const isAdmin = await SessionService.isAdmin();
+  const isPageEditor = await SessionService.isPageEditor();
   const l = i18nService.getLocale(locale);
   const en = locale === 'en';
+  console.log(isPageEditor);
 
   return (
     <ContentPane>
       <h2>{l.pages.about}</h2>
-      {isAdmin && <ActionLink href="/pages/new">{l.pages.create}</ActionLink>}
+      {isPageEditor && (
+        <ActionLink href="/pages/new">{l.pages.create}</ActionLink>
+      )}
       <Divider />
       <ul className={styles.links}>
         <DivisionPages en={en} slug={'/pages'} />

--- a/src/components/DivisionPage/DivisionPage.tsx
+++ b/src/components/DivisionPage/DivisionPage.tsx
@@ -15,11 +15,12 @@ export default async function DivisionPage(
   id?: number,
   gammaSuperGroupId?: string
 ) {
+  const isPageEditor = await SessionService.isPageEditor();
   const isAdmin = await SessionService.isAdmin();
   const canEdit =
     id && gammaSuperGroupId
       ? await SessionService.canEditGroup(gammaSuperGroupId).catch(() => false)
-      : isAdmin;
+      : isPageEditor;
 
   const isEditing = slug[slug.length - 1] === 'edit';
   return isEditing && canEdit

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -59,7 +59,7 @@ export default class SessionService {
   static async isAdmin(s?: Session | null) {
     const session = s ?? (await SessionService.getSession());
 
-    const adminGroups = (process.env.ADMIN_GROUPS || 'styrit,digit').split(',');
+    const adminGroups = (process.env.ADMIN_GROUPS ?? 'styrit,digit').split(',');
     const groups = SessionService.getActiveGroups();
 
     return session?.user?.id

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -59,7 +59,7 @@ export default class SessionService {
   static async isAdmin(s?: Session | null) {
     const session = s ?? (await SessionService.getSession());
 
-    const adminGroups = (process.env.ADMIN_GROUPS || 'styrit').split(',');
+    const adminGroups = (process.env.ADMIN_GROUPS || 'styrit,digit').split(',');
     const groups = SessionService.getActiveGroups();
 
     return session?.user?.id
@@ -78,6 +78,22 @@ export default class SessionService {
     return session?.user?.id
       ? (await groups).some(
           (g) => g.superGroup!.name === corporateRelationsGroup
+        )
+      : false;
+  }
+
+  static async isPageEditor(s?: Session | null) {
+    const session = s ?? (await SessionService.getSession());
+    if (await this.isAdmin(session)) return true;
+
+    const pageEditorGroups = (
+      process.env.PAGE_EDITOR_GROUPS || 'snit,motespresidit'
+    ).split(',');
+    const groups = SessionService.getActiveGroups();
+
+    return session?.user?.id
+      ? (await groups).some((g) =>
+          pageEditorGroups.includes(g.superGroup!.name)
         )
       : false;
   }

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -87,7 +87,7 @@ export default class SessionService {
     if (await this.isAdmin(session)) return true;
 
     const pageEditorGroups = (
-      process.env.PAGE_EDITOR_GROUPS || 'snit,motespresidit'
+      process.env.PAGE_EDITOR_GROUPS ?? 'snit,motespresidit'
     ).split(',');
     const groups = SessionService.getActiveGroups();
 


### PR DESCRIPTION
# Key features
- Adds ability to give groups page edit access without giving full admin access.
- Fixes some inconsistencies between what the UI showed as allowed vs what the "backend" allowed.

# Known issues
- The page edit features always redirects to /groups regardless of what the previous page was. This is an existing issue.


