### PR TITLE
build(Docker): Add OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.19.5-alpine AS deps
+FROM node:24.11.0-alpine AS deps
 LABEL maintainer="digIT <digit@chalmers.it>"
 
 RUN apk add --no-cache libc6-compat
@@ -11,7 +11,9 @@ RUN pnpm i --frozen-lockfile
 ##########################
 #      BUILD STAGE       #
 ##########################
-FROM node:20.19.5-alpine AS builder
+FROM node:24.11.0-alpine AS builder
+
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
@@ -22,7 +24,9 @@ RUN yarn build
 ##########################
 #    PRODUCTION STAGE    #
 ##########################
-FROM node:20.19.5-alpine AS runner
+FROM node:24.11.0-alpine AS runner
+
+RUN apk add --no-cache openssl
 
 WORKDIR /app
 ENV NODE_ENV=production


### PR DESCRIPTION
Fixes an issue where Prisma complains about having no OpenSSL version and proceeds to try and write to a read-only directory