### PR TITLE
Hotfix: Increase max server action file size

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const config: NextConfig = {
     includePaths: [path.join(__dirname, 'styles')],
     prependData: `@use "@/styles/variables.scss" as *;`
   },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '500mb'
+    }
+  },
   output: 'standalone'
 };
 


### PR DESCRIPTION
Fixes issues caused by default action body max being 1MB.