### PR TITLE
Hide non-published news by groups in /api/news

### DIFF
--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -119,7 +119,7 @@ export default class NewsService {
           {
             writtenFor: {
               gammaSuperGroupId: {
-                in: groupIds
+                in: groupIds ?? []
               }
             }
           }


### PR DESCRIPTION
There is an error in `newsService.getPage` where if `groupIds` is `undefined` (as it is in the news API) then posts by all groups will be included. This PR fixes this by adding no groups as the default.