### PR TITLE
Error handling for news notifications

### DIFF
--- a/src/app/api/news/[id]/route.ts
+++ b/src/app/api/news/[id]/route.ts
@@ -18,7 +18,7 @@ export async function GET(
     return ApiService.jsonError('News post not found', 404);
   }
 
-  switch (queryParams.type ?? 'json') {
+  switch (queryParams.format ?? 'json') {
     case 'slack':
       const lang = queryParams.lang === 'en' ? 'EN' : 'SV';
       return NextResponse.json(await NewsService.serializeToSlack(id, lang));

--- a/src/app/api/news/[id]/route.ts
+++ b/src/app/api/news/[id]/route.ts
@@ -7,20 +7,20 @@ export async function GET(
   request: NextRequest,
   ctx: { params: Promise<{ id: string }> }
 ) {
+  const search = request.nextUrl.searchParams;
   const params = await ctx.params;
-  const queryParams = Object.fromEntries(new URL(request.url).searchParams);
-  const id: number = parseInt(params.id);
 
-  if (isNaN(id)) return ApiService.jsonError('Invalid news id');
+  const id: number = parseInt(params.id);
+  if (isNaN(id) || id < 0) return ApiService.jsonError('Invalid news id');
 
   const newsPost = await NewsService.get(id);
   if (newsPost === null || newsPost.status !== PostStatus.PUBLISHED) {
     return ApiService.jsonError('News post not found', 404);
   }
 
-  switch (queryParams.format ?? 'json') {
+  switch (search.get('format') ?? 'json') {
     case 'slack':
-      const lang = queryParams.lang === 'en' ? 'EN' : 'SV';
+      const lang = search.get('lang') === 'en' ? 'EN' : 'SV';
       return NextResponse.json(await NewsService.serializeToSlack(id, lang));
     case 'json':
     default:

--- a/src/app/api/news/[id]/route.ts
+++ b/src/app/api/news/[id]/route.ts
@@ -4,10 +4,11 @@ import { PostStatus } from '@prisma/client';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   ctx: { params: Promise<{ id: string }> }
 ) {
   const params = await ctx.params;
+  const queryParams = Object.fromEntries(new URL(request.url).searchParams);
   const id: number = parseInt(params.id);
 
   if (isNaN(id)) return ApiService.jsonError('Invalid news id');
@@ -17,5 +18,12 @@ export async function GET(
     return ApiService.jsonError('News post not found', 404);
   }
 
-  return NextResponse.json(newsPost);
+  switch (queryParams.type ?? 'json') {
+    case 'slack':
+      const lang = queryParams.lang === 'en' ? 'EN' : 'SV';
+      return NextResponse.json(await NewsService.serializeToSlack(id, lang));
+    case 'json':
+    default:
+      return NextResponse.json(newsPost);
+  }
 }

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -1,6 +1,11 @@
 import prisma from '@/prisma';
 import { PostStatus } from '@prisma/client';
-import NotifyService from './notifyService';
+import NotifyService, { SlackWebhookNotifier } from './notifyService';
+import { Language } from '@prisma/client';
+import GammaService from './gammaService';
+import { marked } from 'marked';
+import { baseUrl } from 'marked-base-url';
+import DivisionGroupService from './divisionGroupService';
 
 export default class NewsService {
   static async getAll() {
@@ -338,5 +343,23 @@ export default class NewsService {
         })
         .then((res) => NotifyService.notifyNewsPost(res));
     });
+  }
+
+  static async serializeToSlack(id: number, language: Language) {
+    const post = await prisma.newsPost.findUnique({
+      where: {
+        id
+      },
+      include: {
+        writtenFor: true,
+        connectedEvents: true
+      }
+    });
+    if (!post) return null;
+
+    const notifier = new SlackWebhookNotifier('', language);
+    const postData = await notifier.serializeNewsPost(post);
+
+    return postData;
   }
 }

--- a/src/services/newsService.ts
+++ b/src/services/newsService.ts
@@ -2,10 +2,6 @@ import prisma from '@/prisma';
 import { PostStatus } from '@prisma/client';
 import NotifyService, { SlackWebhookNotifier } from './notifyService';
 import { Language } from '@prisma/client';
-import GammaService from './gammaService';
-import { marked } from 'marked';
-import { baseUrl } from 'marked-base-url';
-import DivisionGroupService from './divisionGroupService';
 
 export default class NewsService {
   static async getAll() {

--- a/src/services/notifyService.ts
+++ b/src/services/notifyService.ts
@@ -144,7 +144,7 @@ class SlackWebhookNotifier implements Notifier {
       });
   }
 
-  async notifyNewsPost(post: Prisma.NewsPostGetPayload<{}>) {
+  public async serializeNewsPost(post: Prisma.NewsPostGetPayload<{}>) {
     const nick =
       (await GammaService.getNick(post.writtenByGammaUserId)) ||
       (this.language === Language.EN ? 'Unknown user' : 'Okänd användare');
@@ -173,49 +173,134 @@ class SlackWebhookNotifier implements Notifier {
         ? `News published: *${post.titleEn}*${group ? ` for *${group.prettyName}*` : ''} by *${nick}*`
         : `Nyhet publicerad: *${post.titleSv}*${group ? ` för *${group.prettyName}*` : ''} av *${nick}*`;
 
+    return {
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: msg
+          }
+        }
+      ],
+      attachments: [
+        {
+          color: '#00a8d3',
+          blocks: [
+            {
+              type: 'header',
+              text: {
+                type: 'plain_text',
+                text: title
+              }
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*<${process.env.BASE_URL ?? 'http://localhost:3000'}/post/${post.id}|${
+                  this.language === Language.EN
+                    ? 'Read on chalmers.it'
+                    : 'Läs på chalmers.it'
+                }>*`
+              }
+            },
+            {
+              type: 'divider'
+            },
+            ...content
+          ]
+        }
+      ] as MessageAttachment[]
+    };
+  }
+
+  async serializeNewsPostFallback(post: Prisma.NewsPostGetPayload<{}>) {
+    const nick =
+      (await GammaService.getNick(post.writtenByGammaUserId)) ||
+      (this.language === Language.EN ? 'Unknown user' : 'Okänd användare');
+    const group =
+      post.divisionGroupId !== null
+        ? await DivisionGroupService.getInfo(post.divisionGroupId)
+        : null;
+    const title = this.language === Language.EN ? post.titleEn : post.titleSv;
+    const msg =
+      this.language === Language.EN
+        ? `News published: *${post.titleEn}*${group ? ` for *${group.prettyName}*` : ''} by *${nick}*`
+        : `Nyhet publicerad: *${post.titleSv}*${group ? ` för *${group.prettyName}*` : ''} av *${nick}*`;
+
+    return {
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: msg
+          }
+        }
+      ],
+      attachments: [
+        {
+          color: '#00a8d3',
+          blocks: [
+            {
+              type: 'header',
+              text: {
+                type: 'plain_text',
+                text: title
+              }
+            },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `*<${process.env.BASE_URL ?? 'http://localhost:3000'}/post/${post.id}|${
+                  this.language === Language.EN
+                    ? 'Read on chalmers.it'
+                    : 'Läs på chalmers.it'
+                }>*`
+              }
+            }
+          ]
+        }
+      ] as MessageAttachment[]
+    };
+  }
+
+  async notifyNewsPost(post: Prisma.NewsPostGetPayload<{}>) {
+    const postData = await this.serializeNewsPost(post);
     const res = await fetch(this.webhook, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({
-        text: msg,
-        attachments: [
-          {
-            color: '#00a8d3',
-            blocks: [
-              {
-                type: 'header',
-                text: {
-                  type: 'plain_text',
-                  text: title
-                }
-              },
-              {
-                type: 'section',
-                text: {
-                  type: 'mrkdwn',
-                  text: `*<${process.env.BASE_URL ?? 'http://localhost:3000'}/post/${post.id}|${
-                    this.language === Language.EN
-                      ? 'Read on chalmers.it'
-                      : 'Läs på chalmers.it'
-                  }>*`
-                }
-              },
-              {
-                type: 'divider'
-              },
-              ...content
-            ]
-          }
-        ] as MessageAttachment[]
-      })
+      body: JSON.stringify(postData)
     });
-    if (!res.ok)
+    if (!res.ok) {
       console.trace(
-        'Request failed with response:',
+        'Failed to notify news post',
+        post.id,
+        'with response:',
         res.status,
         await res.text()
       );
+
+      if (res.status === 400) {
+        console.warn(
+          'Falling back to simpler message format for news post',
+          post.id
+        );
+        const fallbackData = await this.serializeNewsPostFallback(post);
+        await fetch(this.webhook, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(fallbackData)
+        });
+      }
+    }
   }
 }
+
+export { SlackWebhookNotifier };


### PR DESCRIPTION
Mainly resolves issues where news post notifications are rejected by Slack, often due to `invalid_attachments`. Retries sending a notification without content if failure mode is known.

Also changes `/api/news/[id]` so that users can get the Slack serialized content, mainly for debugging purposes.

Tested working in a developer sandbox.