### PR TITLE
Feat/news drafts

### DIFF
--- a/src/app/[locale]/(main-content)/post/new/page.tsx
+++ b/src/app/[locale]/(main-content)/post/new/page.tsx
@@ -16,7 +16,7 @@ export default async function Page(props: {
   const groups = await SessionService.getActiveAddedGroups();
 
   if (!(await SessionService.isActive())) {
-    // return <Forbidden />;
+    return <Forbidden />;
   }
 
   return (

--- a/src/app/[locale]/(main-content)/post/new/page.tsx
+++ b/src/app/[locale]/(main-content)/post/new/page.tsx
@@ -16,7 +16,7 @@ export default async function Page(props: {
   const groups = await SessionService.getActiveAddedGroups();
 
   if (!(await SessionService.isActive())) {
-    return <Forbidden />;
+    // return <Forbidden />;
   }
 
   return (

--- a/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -140,6 +140,7 @@ interface MilkdownEditorProps {
       url: string;
     }[]
   >;
+  onChange?: (markdown : string) => void;
   localFiles: {
     [key: string]: File;
   };
@@ -149,7 +150,7 @@ interface MilkdownEditorProps {
 const MilkdownEditor = React.forwardRef<
   { getMarkdown: () => string },
   MilkdownEditorProps
->(({ defaultMd, onUpload, locale, localFiles }, ref) => {
+>(({ defaultMd, onUpload,onChange, locale, localFiles }, ref) => {
   const l = i18nService.getLocale(locale);
 
   const [markdown, setMarkdown] = React.useState(defaultMd || '');
@@ -206,6 +207,9 @@ const MilkdownEditor = React.forwardRef<
           ...prev,
           uploader
         }));
+        ctx.get(listenerCtx).markdownUpdated((_ctx,md)=>{
+          onChange?.(md);
+        })
       })
       .use(listener)
       .use(history)
@@ -452,7 +456,7 @@ const MilkdownEditor = React.forwardRef<
       </div>
       <textarea
         value={markdown}
-        onChange={(e) => setMarkdown(e.target.value)}
+        onChange={(e) => {setMarkdown(e.target.value); onChange?.(e.target.value)}}
         hidden={viewMode !== 'raw'}
         className={styles.rawEditor}
         onDragOver={(e) => {
@@ -481,17 +485,19 @@ export const MarkdownEditor = React.forwardRef<
         url: string;
       }[]
     >;
+    onChange?: (markdown : string) => void;
     locale: string;
     localFiles?: {
       [key: string]: File;
     };
   }
->(({ defaultMd, onUpload, locale, localFiles }, ref) => {
+>(({ defaultMd, onUpload, onChange, locale, localFiles }, ref) => {
   return (
     <MilkdownProvider>
       <MilkdownEditor
         defaultMd={defaultMd}
         onUpload={onUpload}
+        onChange={onChange}
         ref={ref}
         locale={locale}
         localFiles={localFiles ?? {}}

--- a/src/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor/MarkdownEditor.tsx
@@ -140,7 +140,7 @@ interface MilkdownEditorProps {
       url: string;
     }[]
   >;
-  onChange?: (markdown : string) => void;
+  onChange?: (markdown: string) => void;
   localFiles: {
     [key: string]: File;
   };
@@ -150,7 +150,7 @@ interface MilkdownEditorProps {
 const MilkdownEditor = React.forwardRef<
   { getMarkdown: () => string },
   MilkdownEditorProps
->(({ defaultMd, onUpload,onChange, locale, localFiles }, ref) => {
+>(({ defaultMd, onUpload, onChange, locale, localFiles }, ref) => {
   const l = i18nService.getLocale(locale);
 
   const [markdown, setMarkdown] = React.useState(defaultMd || '');
@@ -207,9 +207,9 @@ const MilkdownEditor = React.forwardRef<
           ...prev,
           uploader
         }));
-        ctx.get(listenerCtx).markdownUpdated((_ctx,md)=>{
+        ctx.get(listenerCtx).markdownUpdated((_ctx, md) => {
           onChange?.(md);
-        })
+        });
       })
       .use(listener)
       .use(history)
@@ -456,7 +456,10 @@ const MilkdownEditor = React.forwardRef<
       </div>
       <textarea
         value={markdown}
-        onChange={(e) => {setMarkdown(e.target.value); onChange?.(e.target.value)}}
+        onChange={(e) => {
+          setMarkdown(e.target.value);
+          onChange?.(e.target.value);
+        }}
         hidden={viewMode !== 'raw'}
         className={styles.rawEditor}
         onDragOver={(e) => {
@@ -485,7 +488,7 @@ export const MarkdownEditor = React.forwardRef<
         url: string;
       }[]
     >;
-    onChange?: (markdown : string) => void;
+    onChange?: (markdown: string) => void;
     locale: string;
     localFiles?: {
       [key: string]: File;

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -319,7 +319,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
           defaultMd={draft?.contentSv}
           ref={contentSvRef}
           onUpload={dropFiles}
-          onChange={(contents)=>{setContentEn(contents)}}
+          onChange={(contents)=>{setContentSv(contents)}}
           locale={newsPost.locale}
           localFiles={uploadQueue}
         />

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -7,7 +7,7 @@ import ActionButton from '@/components/ActionButton/ActionButton';
 import MarkdownEditor from '@/components/MarkdownEditor/MarkdownEditor';
 import TextArea from '@/components/TextArea/TextArea';
 import { GammaGroup } from '@/types/gamma';
-import { useRef, useState } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import DropdownList from '../DropdownList/DropdownList';
 import { marked } from 'marked';
 import style from './NewsPostForm.module.scss';
@@ -18,6 +18,8 @@ import { useRouter } from 'next/navigation';
 import { toast } from 'react-toastify';
 
 const validUploadTypes = Object.values(MediaType);
+
+const LOCAL_DRAFT_KEY = 'LocalDraftKey';
 
 interface NewPostFormProps {
   groups: GammaGroup[];
@@ -43,6 +45,13 @@ interface Event {
   id?: number;
 }
 
+interface EventDraft {
+  titleEn: string;
+  titleSv: string;
+  contentEn: string;
+  contentSv: string;
+}
+
 const emptyEvent: Event = {
   titleEn: '',
   titleSv: '',
@@ -52,6 +61,7 @@ const emptyEvent: Event = {
   location: '',
   id: undefined
 };
+
 
 const NewsPostForm = (newsPost: NewPostFormProps) => {
   marked.use({
@@ -63,9 +73,11 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const l = i18nService.getLocale(newsPost.locale);
   const router = useRouter();
 
+  const draft = loadDraft();
+
   const [group, setGroup] = useState(newsPost.group ?? '');
-  const [titleEn, setTitleEn] = useState(newsPost.titleEn ?? '');
-  const [titleSv, setTitleSv] = useState(newsPost.titleSv ?? '');
+  const [titleEn, setTitleEn] = useState(draft?.titleEn ?? newsPost.titleEn ?? '');
+  const [titleSv, setTitleSv] = useState(draft?.titleSv ?? newsPost.titleSv ?? '');
   const contentEnRef = useRef<{ getMarkdown: () => string }>(null);
   const contentSvRef = useRef<{ getMarkdown: () => string }>(null);
   const [publish, setPublish] = useState(
@@ -82,6 +94,20 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
 
   const [events, setEvents] = useState<Event[]>(newsPost.connectedEvents ?? []);
   const [removeQueue, setRemoveQueue] = useState<number[]>([]);
+
+  useEffect(() => {
+    return () => {
+      try {
+        const contentEn = contentEnRef.current?.getMarkdown() ?? '';
+        const contentSv = contentSvRef.current?.getMarkdown() ?? '';
+
+        localStorage.setItem(
+          LOCAL_DRAFT_KEY,
+          JSON.stringify({ titleEn, titleSv, contentEn, contentSv })
+        );
+      } catch {}
+    };
+  }, [titleEn, titleSv,contentEnRef,contentSvRef]);
 
   const dropFiles = async (f: FileList) => {
     const newQueue = { ...uploadQueue };
@@ -203,6 +229,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         await deleteEvent(id);
       }
 
+      clearDraft();
       router.push('/');
     } catch {
       console.log('Failed to post news article');
@@ -223,6 +250,21 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
     if (id !== undefined) {
       setRemoveQueue([...removeQueue, id]);
     }
+  }
+
+  function loadDraft(): EventDraft | null {
+    try {
+      const loaded = localStorage.getItem(LOCAL_DRAFT_KEY);
+      return loaded ? JSON.parse(loaded) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function clearDraft(){
+    try{
+      localStorage.removeItem(LOCAL_DRAFT_KEY)
+    } catch {}
   }
 
   return (

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -78,6 +78,8 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const [group, setGroup] = useState(newsPost.group ?? '');
   const [titleEn, setTitleEn] = useState(draft?.titleEn ?? newsPost.titleEn ?? '');
   const [titleSv, setTitleSv] = useState(draft?.titleSv ?? newsPost.titleSv ?? '');
+  const [contentEn, setContentEn] = useState(draft?.contentEn ?? newsPost.contentEn ?? '');
+  const [contentSv, setContentSv] = useState(draft?.contentSv ?? newsPost.contentSv ?? '');
   const contentEnRef = useRef<{ getMarkdown: () => string }>(null);
   const contentSvRef = useRef<{ getMarkdown: () => string }>(null);
   const [publish, setPublish] = useState(
@@ -98,8 +100,8 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   useEffect(() => {
     return () => {
       try {
-        const contentEn = contentEnRef.current?.getMarkdown() ?? '';
-        const contentSv = contentSvRef.current?.getMarkdown() ?? '';
+        const contentEn = contentEnRef.current!.getMarkdown() ?? '';
+        const contentSv = contentSvRef.current!.getMarkdown() ?? '';
 
         localStorage.setItem(
           LOCAL_DRAFT_KEY,
@@ -107,7 +109,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         );
       } catch {}
     };
-  }, [titleEn, titleSv,contentEnRef,contentSvRef]);
+  }, [titleEn, titleSv,contentEn,contentSv]);
 
   const dropFiles = async (f: FileList) => {
     const newQueue = { ...uploadQueue };
@@ -298,9 +300,10 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         />
         <h2>{l.editor.content} (Eng)</h2>
         <MarkdownEditor
-          defaultMd={newsPost.contentEn}
+          defaultMd={draft?.contentEn}
           ref={contentEnRef}
           onUpload={dropFiles}
+          onChange={(contents)=>{setContentEn(contents)}}
           locale={newsPost.locale}
           localFiles={uploadQueue}
         />
@@ -308,14 +311,15 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         <h2>{l.editor.title} (Sv)</h2>
         <TextArea
           value={titleSv}
-          onChange={(e) => setTitleSv(e.target.value)}
+          onChange={(e) => {setTitleSv(e.target.value);console.log("settitlesv")}}
           required
         />
         <h2>{l.editor.content} (Sv)</h2>
         <MarkdownEditor
-          defaultMd={newsPost.contentSv}
+          defaultMd={draft?.contentSv}
           ref={contentSvRef}
           onUpload={dropFiles}
+          onChange={(contents)=>{setContentEn(contents)}}
           locale={newsPost.locale}
           localFiles={uploadQueue}
         />

--- a/src/components/NewsPostForm/NewsPostForm.tsx
+++ b/src/components/NewsPostForm/NewsPostForm.tsx
@@ -62,7 +62,6 @@ const emptyEvent: Event = {
   id: undefined
 };
 
-
 const NewsPostForm = (newsPost: NewPostFormProps) => {
   marked.use({
     pedantic: false,
@@ -76,10 +75,18 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
   const draft = loadDraft();
 
   const [group, setGroup] = useState(newsPost.group ?? '');
-  const [titleEn, setTitleEn] = useState(draft?.titleEn ?? newsPost.titleEn ?? '');
-  const [titleSv, setTitleSv] = useState(draft?.titleSv ?? newsPost.titleSv ?? '');
-  const [contentEn, setContentEn] = useState(draft?.contentEn ?? newsPost.contentEn ?? '');
-  const [contentSv, setContentSv] = useState(draft?.contentSv ?? newsPost.contentSv ?? '');
+  const [titleEn, setTitleEn] = useState(
+    draft?.titleEn ?? newsPost.titleEn ?? ''
+  );
+  const [titleSv, setTitleSv] = useState(
+    draft?.titleSv ?? newsPost.titleSv ?? ''
+  );
+  const [contentEn, setContentEn] = useState(
+    draft?.contentEn ?? newsPost.contentEn ?? ''
+  );
+  const [contentSv, setContentSv] = useState(
+    draft?.contentSv ?? newsPost.contentSv ?? ''
+  );
   const contentEnRef = useRef<{ getMarkdown: () => string }>(null);
   const contentSvRef = useRef<{ getMarkdown: () => string }>(null);
   const [publish, setPublish] = useState(
@@ -109,7 +116,7 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         );
       } catch {}
     };
-  }, [titleEn, titleSv,contentEn,contentSv]);
+  }, [titleEn, titleSv, contentEn, contentSv]);
 
   const dropFiles = async (f: FileList) => {
     const newQueue = { ...uploadQueue };
@@ -263,9 +270,9 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
     }
   }
 
-  function clearDraft(){
-    try{
-      localStorage.removeItem(LOCAL_DRAFT_KEY)
+  function clearDraft() {
+    try {
+      localStorage.removeItem(LOCAL_DRAFT_KEY);
     } catch {}
   }
 
@@ -303,7 +310,9 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
           defaultMd={draft?.contentEn}
           ref={contentEnRef}
           onUpload={dropFiles}
-          onChange={(contents)=>{setContentEn(contents)}}
+          onChange={(contents) => {
+            setContentEn(contents);
+          }}
           locale={newsPost.locale}
           localFiles={uploadQueue}
         />
@@ -311,7 +320,10 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
         <h2>{l.editor.title} (Sv)</h2>
         <TextArea
           value={titleSv}
-          onChange={(e) => {setTitleSv(e.target.value);console.log("settitlesv")}}
+          onChange={(e) => {
+            setTitleSv(e.target.value);
+            console.log('settitlesv');
+          }}
           required
         />
         <h2>{l.editor.content} (Sv)</h2>
@@ -319,7 +331,9 @@ const NewsPostForm = (newsPost: NewPostFormProps) => {
           defaultMd={draft?.contentSv}
           ref={contentSvRef}
           onUpload={dropFiles}
-          onChange={(contents)=>{setContentSv(contents)}}
+          onChange={(contents) => {
+            setContentSv(contents);
+          }}
           locale={newsPost.locale}
           localFiles={uploadQueue}
         />


### PR DESCRIPTION
This is releated to a created issue where if you refresh the newspage when writing a newspost you will loose progress. This has been reported to feel very annoying when this happens.

Tried an implementation of how this could work.
I added a onChange property to the MarkdownEditor aswell to implement this feature.
Maybe date and time should be saved aswell but i don't know how i would do that while just doing it with text fields seems a lot easier.