### PR TITLE
fix(ci): Specify pnpm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24.11.0-alpine AS deps
 LABEL maintainer="digIT <digit@chalmers.it>"
 
 RUN apk add --no-cache libc6-compat
-RUN yarn global add pnpm
+RUN yarn global add pnpm@10.28.0
 
 WORKDIR /app
 COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./


### PR DESCRIPTION
There is an issue in the current Dockerfile where yarn installs the latest version of pnpm. As pnpm has updated, it is no longer compatible with the lockfile. This PR locks the version and allows for upgrading when specified rather than potentially breaking over time.